### PR TITLE
Adding logging using rails logger when a signed_message is deprecated

### DIFF
--- a/lib/hestia/version.rb
+++ b/lib/hestia/version.rb
@@ -1,3 +1,3 @@
 module Hestia
-  VERSION = "0.3.3.mb"
+  VERSION = "0.3.7.mb"
 end


### PR DESCRIPTION
This is so we can calculate the number of deprecated cookies per day.