### PR TITLE
Add Support for Rails 4

### DIFF
--- a/lib/hestia/railtie.rb
+++ b/lib/hestia/railtie.rb
@@ -1,4 +1,6 @@
-require "hestia"
+# frozen_string_literal: true
+
+require 'hestia'
 
 module Hestia
   class Railtie < ::Rails::Railtie
@@ -6,10 +8,13 @@ module Hestia
     #
     # See README.md for how to configure this in your application.
     #
-    initializer "hestia.signed_cookie_jar_extension", before: :load_config_initializers do
+    initializer 'hestia.signed_cookie_jar_extension', before: :load_config_initializers do
       extension = case ActionPack::VERSION::MAJOR
-      when 3
-        Hestia::SignedCookieJarExtension::ActionPack3
+                  when 3
+                    Hestia::SignedCookieJarExtension::ActionPack3
+                  when 4
+                    Hestia.check_secret_key_base
+                    Hestia::SignedCookieJarExtension::ActionPack4
       end
 
       ActionDispatch::Cookies::SignedCookieJar.prepend(extension)

--- a/lib/hestia/signed_cookie_jar_extension.rb
+++ b/lib/hestia/signed_cookie_jar_extension.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module Hestia
   module SignedCookieJarExtension
-    autoload :ActionPack3, "hestia/signed_cookie_jar_extension/action_pack_3"
+    autoload :ActionPack3, 'hestia/signed_cookie_jar_extension/action_pack_3'
+    autoload :ActionPack4, 'hestia/signed_cookie_jar_extension/action_pack_4'
   end
 end

--- a/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
+++ b/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'active_support/message_encryptor'
+
+module Hestia
+  module SignedCookieJarExtension
+    module ActionPack4
+      # Public: overridden #initialize method
+      #
+      # In rails, `secrets' will be given the value of `Rails.application.config.secret_token'. That's the current secret token.
+      # This also reads from `Rails.application.config.deprecated_secret_token` for deprecated token(s) to use. It can be undefined, a
+      # string or an array of string.
+      #
+      # parent_jar [ActionDispatch::Cookies] the parent jar creating this signed cookie jar
+      # secret [String] current secret token. Used to verify & sign cookies.
+      #
+      def initialize(parent_jar, key_generator, options = {})
+        super
+
+        # Find the deprecated secrets, if there are any
+        deprecated_secrets = if Rails.application.config.respond_to?(:deprecated_secret_token)
+                               # This could be a single string!
+                               Array(Rails.application.config.deprecated_secret_token)
+                             else
+                               []
+        end
+
+        # Grab the `config.secret_token` value from its generator
+        active_secret = key_generator.generate_key(@options[:signed_cookie_salt])
+
+        # Take the deprecated secrets through the same generator code
+        deprecated_secrets.map do |secret|
+          ActiveSupport::LegacyKeyGenerator.new(secret).generate_key(@options[:signed_cookie_salt])
+        end
+
+        serializer = ActiveSupport::MessageEncryptor::NullSerializer
+
+        # Finally, override @verifier with our own multi verifier containing all the secrets
+        @verifier = Hestia::MessageMultiVerifier.new(current_secret: active_secret, deprecated_secrets: deprecated_secrets, options: { serializer: serializer })
+      end
+    end
+  end
+end

--- a/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
+++ b/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
@@ -51,7 +51,7 @@ module Hestia
 
         # Finally, override @verifier with our own multi verifier containing all the secrets
         @verifier = Hestia::MessageMultiVerifier.new(
-          current_secret: secret,
+          current_secret: active_secret,
           options: options,
           deprecated_secrets: deprecated_secrets,
           deprecated_options: deprecated_options

--- a/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
+++ b/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb
@@ -5,6 +5,8 @@ require 'active_support/message_encryptor'
 module Hestia
   module SignedCookieJarExtension
     module ActionPack4
+      require 'safe_json_serializer'
+
       # Public: overridden #initialize method
       #
       # In rails, `secrets' will be given the value of `Rails.application.config.secret_token'. That's the current secret token.
@@ -17,12 +19,24 @@ module Hestia
       def initialize(parent_jar, key_generator, options = {})
         super
 
+        options = if Rails.application.config.respond_to?(:options)
+                    Rails.application.config.options
+                  else
+                    {}
+        end
+
         # Find the deprecated secrets, if there are any
         deprecated_secrets = if Rails.application.config.respond_to?(:deprecated_secret_token)
                                # This could be a single string!
                                Array(Rails.application.config.deprecated_secret_token)
                              else
                                []
+        end
+
+        deprecated_options = if Rails.application.config.respond_to?(:deprecated_options)
+                               Array(Rails.application.config.deprecated_options)
+                             else
+                               [{}]
         end
 
         # Grab the `config.secret_token` value from its generator
@@ -36,7 +50,12 @@ module Hestia
         serializer = ActiveSupport::MessageEncryptor::NullSerializer
 
         # Finally, override @verifier with our own multi verifier containing all the secrets
-        @verifier = Hestia::MessageMultiVerifier.new(current_secret: active_secret, deprecated_secrets: deprecated_secrets, options: { serializer: serializer })
+        @verifier = Hestia::MessageMultiVerifier.new(
+          current_secret: secret,
+          options: options,
+          deprecated_secrets: deprecated_secrets,
+          deprecated_options: deprecated_options
+        )
       end
     end
   end


### PR DESCRIPTION
Hestia Support for: https://github.com/Mixbook/product/issues/12411

## Summary

1. [Hestia](https://github.com/fac/hestia) is a wrapper calling [Message Verifier](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/message_verifier.rb) under the hood twice: once for `deprecated_token` and once new `token`.
2. There a couple of differences between Rails 3 and Rails 4 on Hestia side:
  - It introduces [Null Serializer](https://github.com/fac/hestia/commit/505f41a04fee0bb71997c9697c129f94ad7fe7c4#diff-00bb151f6566fe2380577629f1f15184e9ac30dc88dcb0b66f793bf31c2a8e0aL32) which is ignored by our setup in `mixbook_com` anyway. Our setup sets [https://github.com/Mixbook/mixbook_com/commit/d6e0656a6ab00ccb7d96d7f67be99494b3164ffc#diff-3fd2c9950baf7d06c0402c91694187bd87cedb40c948c0988aff42429faebb1dR11](custom serializer) which gets passed to `MessageVerifier` regardless of what we have setup in Hestia gem.
  - Hestia Action Pack for Rails 4 has [3 params in constructor](https://github.com/fac/hestia/blob/master/lib/hestia/signed_cookie_jar_extension/action_pack_4.rb#L15) compared to [only 2 in Rails 3](https://github.com/fac/hestia/blob/505f41a04fee0bb71997c9697c129f94ad7fe7c4/lib/hestia/signed_cookie_jar_extension/action_pack_3.rb#L13). It is part of the bigger refactoring moving `ensure_secret_token` from `Cookies in Rails 3`[https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/middleware/cookies.rb#L317] and splitting part of it to [KeyGenerator in Rails 4](https://github.com/rails/rails/blob/4-0-stable/activesupport/lib/active_support/key_generator.rb#L42). All the Hestia changes just mirror that changes without adding much functionality.
3. Testing  proves the assumptions read in code:
 - When using `SafeJSONSerializer` + `secret_token` on Rails 3, we are not logged out when starting the Web Server on Rails 4.
 - If we do the same test `Marshal` + `deprecated_secret_token` on Rails 3, we are still logged in when starting Rails 4.
 - Just for Sanity Check, switching the Serializers + Restart, logs us out immediately.
 - `mixbook_com_session` + `remember_me` cookies stay the same and are valid on restart on Rails 4.
